### PR TITLE
fix sso integration issue

### DIFF
--- a/templates/apicurio-template.yml
+++ b/templates/apicurio-template.yml
@@ -293,7 +293,7 @@ objects:
             protocol: TCP
           env:
              - name: APICURIO_KC_AUTH_URL
-               value: https://${AUTH_ROUTE}/auth
+               value: ${AUTH_ROUTE}
              - name: APICURIO_KC_REALM
                value: ${KC_REALM}
              - name: APICURIO_DB_DRIVER_NAME

--- a/templates/lab-oauthclient.yml
+++ b/templates/lab-oauthclient.yml
@@ -45,7 +45,7 @@ objects:
       app: "sso"
   secret: ${OPENSHIFT_OAUTH_CLIENT_SECRET}
   redirectURIs:
-  - http://${KEYCLOAK_ROUTE_HOSTNAME}/
+  - ${KEYCLOAK_ROUTE_HOSTNAME}/
   grantMethod: prompt
 - kind: ConfigMap
   apiVersion: v1

--- a/templates/microcks-persistent-no-keycloak-template.yml
+++ b/templates/microcks-persistent-no-keycloak-template.yml
@@ -219,7 +219,7 @@ objects:
           - name: TEST_CALLBACK_URL
             value: http://${APP_NAME}:8080
           - name: KEYCLOAK_URL
-            value: http://${KEYCLOAK_ROUTE_HOSTNAME}/auth
+            value: ${KEYCLOAK_ROUTE_HOSTNAME}
           resources:
             limits:
               memory: "${MEMORY_LIMIT}"


### PR DESCRIPTION
I found  an issue in the kerycloak integration with Apicurio and Microcks. 
Apicurio Pod has setup this configuration parameter (bad format two times "http:" and "auth"):
APICURIO_KC_AUTH_URL https://http://sso-unsecured.apps.40ac.rhte.opentlc.com/auth/auth

The same happened in Microcks pod with KEYCLOAK_URL parameter and in the URL_REDIRECT of laboauth OAuthClient.

I changed in this fork the templates for all of those items, I think would work, I don't test it.